### PR TITLE
Meta vj

### DIFF
--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -48,8 +48,17 @@ VJ & VJ::frequency(uint32_t start_time, uint32_t end_time, uint32_t headway_secs
 }
 
 
-VJ::VJ(builder & b, const std::string &line_name, const std::string &validity_pattern, const std::string &/*block_id*/, bool wheelchair_boarding, const std::string& uri) : b(b){
+VJ::VJ(builder & b, const std::string &line_name, const std::string &validity_pattern, const std::string &/*block_id*/, bool wheelchair_boarding, const std::string& uri, std::string meta_vj_name) : b(b){
     vj = new navitia::type::VehicleJourney();
+
+    //if we have a meta_vj, we add it in that
+    if (! meta_vj_name.empty()) {
+        b.data->pt_data->meta_vj[meta_vj_name].theoric_vj.push_back(vj);
+    } else {
+        b.data->pt_data->meta_vj[uri].theoric_vj.push_back(vj); //we add a meta vj around this vj
+    }
+
+
     vj->idx = b.data->pt_data->vehicle_journeys.size();
     b.data->pt_data->vehicle_journeys.push_back(vj);
 
@@ -243,14 +252,15 @@ SA & SA::operator()(const std::string & sp_name, double x, double y, bool wheelc
 }
 
 
-VJ builder::vj(const std::string &line_name, const std::string &validity_pattern, const std::string & block_id, const bool wheelchair_boarding, const std::string& uri){
-    return vj("base_network", line_name, validity_pattern, block_id, wheelchair_boarding, uri);
+VJ builder::vj(const std::string &line_name, const std::string &validity_pattern, const std::string & block_id,
+               const bool wheelchair_boarding, const std::string& uri, std::string meta_vj){
+    return vj("base_network", line_name, validity_pattern, block_id, wheelchair_boarding, uri, meta_vj);
 }
 
 VJ builder::vj(const std::string &network_name, const std::string &line_name,
                const std::string &validity_pattern, const std::string & block_id,
-               const bool wheelchair_boarding, const std::string& uri){
-    auto res = VJ(*this, line_name, validity_pattern, block_id, wheelchair_boarding, uri);
+               const bool wheelchair_boarding, const std::string& uri, std::string meta_vj){
+    auto res = VJ(*this, line_name, validity_pattern, block_id, wheelchair_boarding, uri, meta_vj);
     auto vj = this->data->pt_data->vehicle_journeys.back();
     auto it = this->nts.find(network_name);
     if(it == this->nts.end()){

--- a/source/ed/build_helper.h
+++ b/source/ed/build_helper.h
@@ -51,7 +51,7 @@ struct VJ {
     navitia::type::VehicleJourney * vj;
 
     /// Construit un nouveau vehicle journey
-    VJ(builder & b, const std::string &line_name, const std::string &validity_pattern, const std::string & block_id, bool is_adapted = true, const std::string& uri="");
+    VJ(builder & b, const std::string &line_name, const std::string &validity_pattern, const std::string & block_id, bool is_adapted = true, const std::string& uri="", std::string meta_vj_name = "");
 
     /// Ajout un nouveau stopTime
     /// Lorsque le depart n'est pas specifié, on suppose que c'est le même qu'à l'arrivée
@@ -100,8 +100,8 @@ struct builder{
     }
 
     /// Crée un vehicle journey
-    VJ vj(const std::string &line_name, const std::string &validity_pattern = "11111111", const std::string & block_id="", const bool wheelchair_boarding = true, const std::string& uri="");
-    VJ vj(const std::string &network_name, const std::string &line_name, const std::string &validity_pattern = "11111111", const std::string & block_id="", const bool wheelchair_boarding = true, const std::string& uri="");
+    VJ vj(const std::string &line_name, const std::string &validity_pattern = "11111111", const std::string & block_id="", const bool wheelchair_boarding = true, const std::string& uri="", std::string meta_vj="");
+    VJ vj(const std::string &network_name, const std::string &line_name, const std::string &validity_pattern = "11111111", const std::string & block_id="", const bool wheelchair_boarding = true, const std::string& uri="", std::string meta_vj="");
 
     /// Crée un nouveau stop area
     SA sa(const std::string & name, double x = 0, double y = 0, const bool is_adapted = true);

--- a/source/ed/connectors/fusio_parser.h
+++ b/source/ed/connectors/fusio_parser.h
@@ -110,6 +110,7 @@ struct TripsFusioHandler : public GenericHandler {
     std::vector<ed::types::VehicleJourney*> get_split_vj(Data& data, const csv_row& row, bool is_first_line);
     void handle_line(Data& data, const csv_row& line, bool is_first_line);
     const std::vector<std::string> required_headers() const { return {"route_id", "service_id", "trip_id", "physical_mode_id", "company_id"}; }
+    void finish(Data&);
 };
 
 struct StopTimeFusioHandler : public StopTimeGtfsHandler {

--- a/source/ed/connectors/gtfs_parser.h
+++ b/source/ed/connectors/gtfs_parser.h
@@ -90,6 +90,7 @@ struct GtfsData {
     std::unordered_map<std::string, ed::types::Contributor*> contributor_map;
     typedef std::vector<ed::types::StopPoint*> vector_sp;
     std::unordered_map<std::string, vector_sp> sa_spmap;
+    std::set<std::string> vj_uri; //we store all vj_uri not to give twice the same uri (since we split some)
 
     // timezone management
     TzHandler tz;
@@ -132,6 +133,8 @@ inline bool is_active(int col_idx, const std::vector<std::string>& row) {
 inline bool is_valid(int col_idx, const std::vector<std::string>& row) {
     return (has_col(col_idx, row) && (!row[col_idx].empty()));
 }
+
+std::string generate_unique_vj_uri(const GtfsData& gtfs_data, const std::string original_uri, int cpt_vj);
 
 
 /**

--- a/source/ed/data.cpp
+++ b/source/ed/data.cpp
@@ -258,19 +258,35 @@ void Data::clean(){
     // The same but now with vehicle_journey's
     num_elements = vehicle_journeys.size();
     for(size_t to_erase : erasest) {
-        if(vehicle_journeys[to_erase]->next_vj) {
-            vehicle_journeys[to_erase]->next_vj->prev_vj = nullptr;
+        auto vj = vehicle_journeys[to_erase];
+        if(vj->next_vj) {
+            vj->next_vj->prev_vj = nullptr;
         }
-        if(vehicle_journeys[to_erase]->prev_vj) {
-            vehicle_journeys[to_erase]->prev_vj->next_vj = nullptr;
+        if(vj->prev_vj) {
+            vj->prev_vj->next_vj = nullptr;
         }
-        delete vehicle_journeys[to_erase];
+        //we need to remove the vj from the meta vj
+        auto& metavj = meta_vj_map[vj->meta_vj_name];
+        bool found = false;
+        for (auto it = metavj.theoric_vj.begin() ; it != metavj.theoric_vj.end() ; ++it) {
+            if (*it == vj) {
+                metavj.theoric_vj.erase(it);
+                found = true;
+                break;
+            }
+        }
+        if (! found) {
+            throw navitia::exception("construction problem, impossible to find the vj " + vj->uri + " in the meta vj " + vj->meta_vj_name);
+        }
+        if (metavj.theoric_vj.empty()) {
+            //we remove the meta vj
+            meta_vj_map.erase(vj->meta_vj_name);
+        }
+        delete vj;
         vehicle_journeys[to_erase] = vehicle_journeys[num_elements - 1];
         num_elements--;
     }
     vehicle_journeys.resize(num_elements);
-
-
 
     LOG4CPLUS_INFO(logger, "Data::clean(): " << erase_overlap <<  " vehicle_journeys have been deleted because they overlap, "
                    << erase_emptiness << " because they do not contain any clean stop_times, and "
@@ -289,7 +305,8 @@ void Data::clean(){
     //@TODO : Attention, it's leaking, it should succeed in erasing objects
     //Ce qu'il y a dans la fin du vecteur apres unique n'est pas garanti, on ne peut pas itérer sur la suite pour effacer
     stop_point_connections.resize(std::distance(stop_point_connections.begin(), it_end));
-    LOG4CPLUS_INFO(logger, "I deleted" + boost::lexical_cast<std::string>(num_elements-stop_point_connections.size()) + " duplicate connections");
+    LOG4CPLUS_INFO(logger, num_elements-stop_point_connections.size()
+                   << " stop point connections deleted because of duplicate connections");
 }
 
 // Functor used to transform an ed object in to an navitia objet.

--- a/source/ed/data.h
+++ b/source/ed/data.h
@@ -73,6 +73,8 @@ public:
 
     std::vector<ed::types::AdminStopArea*>  admin_stop_areas;
 
+    std::map<std::string, types::MetaVehicleJourney> meta_vj_map; //meta vj by original vj name
+
     /**
          * trie les différentes donnée et affecte l'idx
          *

--- a/source/ed/ed_persistor.cpp
+++ b/source/ed/ed_persistor.cpp
@@ -307,6 +307,10 @@ void EdPersistor::persist(const ed::Data& data, const navitia::type::MetaData& m
     LOG4CPLUS_INFO(logger, "Begin: insert vehicle journeys");
     this->insert_vehicle_journeys(data.vehicle_journeys);
     LOG4CPLUS_INFO(logger, "End: insert vehicle journeys");
+    LOG4CPLUS_INFO(logger, "Begin: insert meta vehicle journeys");
+    this->insert_meta_vj(data.meta_vj_map);
+    LOG4CPLUS_INFO(logger, "End: insert meta vehicle journeys");
+
     LOG4CPLUS_INFO(logger, "Begin: insert journey pattern points");
     this->insert_journey_pattern_point(data.journey_pattern_points);
     LOG4CPLUS_INFO(logger, "End: insert journey pattern points");
@@ -402,7 +406,9 @@ void EdPersistor::clean_db(){
                 "navitia.vehicle_properties, navitia.properties, "
                 "navitia.validity_pattern, navitia.network, navitia.parameters, "
                 "navitia.connection, navitia.calendar, navitia.period, "
-                "navitia.week_pattern CASCADE"));
+                "navitia.week_pattern, "
+                "navitia.meta_vj, navitia.meta_vj_link"
+                " CASCADE"));
 }
 
 void EdPersistor::insert_networks(const std::vector<types::Network*>& networks){
@@ -904,6 +910,40 @@ void EdPersistor::insert_vehicle_journeys(const std::vector<types::VehicleJourne
     }
 }
 
+void EdPersistor::insert_meta_vj(const std::map<std::string, types::MetaVehicleJourney>& meta_vjs) {
+    //we insert first the meta vj
+    this->lotus.prepare_bulk_insert("navitia.meta_vj", {"id", "name"});
+    size_t cpt(0);
+    for (const auto& meta_vj_pair: meta_vjs) {
+        this->lotus.insert({std::to_string(cpt), meta_vj_pair.first});
+        cpt++;
+    }
+    this->lotus.finish_bulk_insert();
+
+    //then the links
+    this->lotus.prepare_bulk_insert("navitia.meta_vj_link", {"meta_vj", "vehicle_journey", "vj_class"});
+    cpt = 0;
+    for (const auto& meta_vj_pair: meta_vjs) {
+        const types::MetaVehicleJourney& meta_vj = meta_vj_pair.second;
+        const std::vector<std::pair<std::string, const std::vector<types::VehicleJourney*>& > > list_vj = {
+            {"Theoric", meta_vj.theoric_vj},
+            {"Adapted", meta_vj.adapted_vj},
+            {"RealTime", meta_vj.real_time_vj}
+        };
+
+        for (const auto& name_list: list_vj) {
+            for (const types::VehicleJourney* vj: name_list.second) {
+
+                this->lotus.insert({std::to_string(cpt),
+                                    std::to_string(vj->idx),
+                                    name_list.first
+                                   });
+            }
+        }
+        cpt++;
+    }
+    this->lotus.finish_bulk_insert();
+}
 
 void EdPersistor::insert_admin_stop_areas(const std::vector<types::AdminStopArea*> admin_stop_areas) {
     this->lotus.prepare_bulk_insert("navitia.admin_stop_area", {"admin_id", "stop_area_id"});

--- a/source/ed/ed_persistor.cpp
+++ b/source/ed/ed_persistor.cpp
@@ -407,7 +407,7 @@ void EdPersistor::clean_db(){
                 "navitia.validity_pattern, navitia.network, navitia.parameters, "
                 "navitia.connection, navitia.calendar, navitia.period, "
                 "navitia.week_pattern, "
-                "navitia.meta_vj, navitia.meta_vj_link"
+                "navitia.meta_vj, navitia.rel_metavj_vj"
                 " CASCADE"));
 }
 
@@ -921,7 +921,7 @@ void EdPersistor::insert_meta_vj(const std::map<std::string, types::MetaVehicleJ
     this->lotus.finish_bulk_insert();
 
     //then the links
-    this->lotus.prepare_bulk_insert("navitia.meta_vj_link", {"meta_vj", "vehicle_journey", "vj_class"});
+    this->lotus.prepare_bulk_insert("navitia.rel_metavj_vj", {"meta_vj", "vehicle_journey", "vj_class"});
     cpt = 0;
     for (const auto& meta_vj_pair: meta_vjs) {
         const types::MetaVehicleJourney& meta_vj = meta_vj_pair.second;

--- a/source/ed/ed_persistor.h
+++ b/source/ed/ed_persistor.h
@@ -77,6 +77,7 @@ private:
     void insert_validity_patterns(const std::vector<types::ValidityPattern*>& validity_patterns);
     void insert_vehicle_properties(const std::vector<types::VehicleJourney*>& vehicle_journeys);
     void insert_vehicle_journeys(const std::vector<types::VehicleJourney*>& vehicle_journeys);
+    void insert_meta_vj(const std::map<std::string, types::MetaVehicleJourney>& meta_vjs);
 
     void insert_journey_pattern_point(const std::vector<types::JourneyPatternPoint*>& journey_pattern_points);
 

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -696,7 +696,7 @@ void EdReader::fill_meta_vehicle_journeys(nt::Data& data, pqxx::work& work) {
     //then we fill the links
     std::string request = "SELECT l.meta_vj as metavj, "
             " l.vehicle_journey as vehicle_journey, l.vj_class as vj_class, meta.name as name"
-            " from navitia.meta_vj as meta, navitia.meta_vj_link as l"
+            " from navitia.meta_vj as meta, navitia.rel_metavj_vj as l"
             " WHERE meta.id = l.meta_vj";
     pqxx::result result = work.exec(request);
     for(auto const_it = result.begin(); const_it != result.end(); ++const_it) {

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -64,6 +64,7 @@ void EdReader::fill(navitia::type::Data& data, const double min_non_connected_gr
 
     this->fill_validity_patterns(data, work);
     this->fill_vehicle_journeys(data, work);
+    this->fill_meta_vehicle_journeys(data, work);
 
 
     this->fill_stop_times(data, work);
@@ -690,7 +691,42 @@ void EdReader::fill_vehicle_journeys(nt::Data& data, pqxx::work& work){
     }
 }
 
-void EdReader::fill_stop_times(nt::Data& data, pqxx::work& work){
+
+void EdReader::fill_meta_vehicle_journeys(nt::Data& data, pqxx::work& work) {
+    //then we fill the links
+    std::string request = "SELECT l.meta_vj as metavj, "
+            " l.vehicle_journey as vehicle_journey, l.vj_class as vj_class, meta.name as name"
+            " from navitia.meta_vj as meta, navitia.meta_vj_link as l"
+            " WHERE meta.id = l.meta_vj";
+    pqxx::result result = work.exec(request);
+    for(auto const_it = result.begin(); const_it != result.end(); ++const_it) {
+        const std::string name = const_it["name"].as<std::string>();
+
+        auto& meta_vj = data.pt_data->meta_vj[name];
+
+        const auto vj_idx = const_it["vehicle_journey"].as<idx_t>();
+        const auto vj_it = vehicle_journey_map.find(vj_idx);
+
+        if ( vj_it == vehicle_journey_map.end()) {
+            LOG4CPLUS_ERROR(log4cplus::Logger::getInstance("log"), "Impossible to find the vj " << vj_idx << ", we won't add it in a meta vj");
+            continue;
+        }
+        auto* vj = vj_it->second;
+
+        const std::string vj_class = const_it["vj_class"].as<std::string>();
+        if (vj_class == "Theoric") {
+            meta_vj.theoric_vj.push_back(vj);
+        } else if (vj_class == "Adapted") {
+            meta_vj.adapted_vj.push_back(vj);
+        } else if (vj_class == "RealTime") {
+            meta_vj.real_time_vj.push_back(vj);
+        } else {
+            throw navitia::exception("technical error, vj class for meta vj should be either Theoric, Adapted or RealTime");
+        }
+    }
+}
+
+void EdReader::fill_stop_times(nt::Data& data, pqxx::work& work) {
     std::string request = "SELECT vehicle_journey_id, journey_pattern_point_id, arrival_time, departure_time, " // 0, 1, 2, 3
         "local_traffic_zone, start_time, end_time, headway_sec, odt, pick_up_allowed, " // 4, 5, 6, 7, 8, 9, 10
         "drop_off_allowed, is_frequency, date_time_estimated, comment " // 11, 12

--- a/source/ed/ed_reader.h
+++ b/source/ed/ed_reader.h
@@ -109,6 +109,7 @@ private:
 
     void fill_journey_pattern_points(navitia::type::Data& data, pqxx::work& work);
     void fill_vehicle_journeys(navitia::type::Data& data, pqxx::work& work);
+    void fill_meta_vehicle_journeys(navitia::type::Data& data, pqxx::work& work);
 
     void fill_stop_times(navitia::type::Data& data, pqxx::work& work);
 

--- a/source/ed/tests/gtfsparser_test.cpp
+++ b/source/ed/tests/gtfsparser_test.cpp
@@ -401,7 +401,7 @@ BOOST_AUTO_TEST_CASE(parse_gtfs){
 
     // same for the vj, all have been split in 9
     BOOST_REQUIRE_EQUAL(data.vehicle_journeys.size(), 11 * 9);
-    BOOST_CHECK_EQUAL(data.vehicle_journeys[0]->uri, "AB1_1");
+    BOOST_CHECK_EQUAL(data.vehicle_journeys[0]->uri, "AB1_dst_1");
     BOOST_REQUIRE(data.vehicle_journeys[0]->tmp_line != nullptr);
     BOOST_CHECK_EQUAL(data.vehicle_journeys[0]->tmp_line->uri, "AB");
     BOOST_REQUIRE(data.vehicle_journeys[0]->validity_pattern != nullptr);
@@ -409,7 +409,7 @@ BOOST_AUTO_TEST_CASE(parse_gtfs){
     BOOST_CHECK_EQUAL(data.vehicle_journeys[0]->name, "to Bullfrog");
     BOOST_CHECK_EQUAL(data.vehicle_journeys[0]->block_id, "1");
     for (int i = 1; i <= 9; ++i) {
-        BOOST_CHECK_EQUAL(data.vehicle_journeys[i-1]->uri, "AB1_" + std::to_string(i));
+        BOOST_CHECK_EQUAL(data.vehicle_journeys[i-1]->uri, "AB1_dst_" + std::to_string(i));
         BOOST_REQUIRE(data.vehicle_journeys[i-1]->validity_pattern != nullptr);
         BOOST_CHECK_EQUAL(data.vehicle_journeys[i-1]->validity_pattern->uri, "FULLW_" + std::to_string(i));
     }
@@ -417,7 +417,7 @@ BOOST_AUTO_TEST_CASE(parse_gtfs){
     //Stop time
     BOOST_REQUIRE_EQUAL(data.stops.size(), 28 * 9);
     BOOST_REQUIRE(data.stops[0]->vehicle_journey != nullptr);
-    BOOST_CHECK_EQUAL(data.stops[0]->vehicle_journey->uri, "STBA_1");
+    BOOST_CHECK_EQUAL(data.stops[0]->vehicle_journey->uri, "STBA_dst_1");
     BOOST_CHECK_EQUAL(data.stops[0]->arrival_time, 6*3600 - 480); //first day is on a non dst period, so the utc offset
     BOOST_CHECK_EQUAL(data.stops[0]->departure_time, 6*3600 - 480); //for los angeles is -480
     BOOST_REQUIRE(data.stops[0]->tmp_stop_point != nullptr);
@@ -425,7 +425,7 @@ BOOST_AUTO_TEST_CASE(parse_gtfs){
     BOOST_CHECK_EQUAL(data.stops[0]->order, 1);
 
     BOOST_REQUIRE(data.stops[1]->vehicle_journey != nullptr);
-    BOOST_CHECK_EQUAL(data.stops[1]->vehicle_journey->uri, "STBA_2");
+    BOOST_CHECK_EQUAL(data.stops[1]->vehicle_journey->uri, "STBA_dst_2");
     BOOST_CHECK_EQUAL(data.stops[1]->arrival_time, 6*3600 - 420); //the second st is on a dst period, so the utc offset
     BOOST_CHECK_EQUAL(data.stops[1]->departure_time, 6*3600 - 420); //for los angeles is -420
     BOOST_REQUIRE(data.stops[1]->tmp_stop_point != nullptr);

--- a/source/ed/types.h
+++ b/source/ed/types.h
@@ -224,6 +224,7 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties{
     StopTime * first_stop_time = nullptr;
     std::string block_id;
     std::string odt_message;
+    std::string meta_vj_name; //link to it's meta vj
 
     bool is_adapted;
     ValidityPattern* adapted_validity_pattern = nullptr;
@@ -324,6 +325,13 @@ struct StopTime : public Nameable {
     navitia::type::StopTime* get_navitia_type() const;
 
     bool operator<(const StopTime& other) const;
+};
+
+
+struct MetaVehicleJourney {
+    std::vector<VehicleJourney*> theoric_vj;
+    std::vector<VehicleJourney*> adapted_vj;
+    std::vector<VehicleJourney*> real_time_vj;
 };
 
 /// Données Geographique

--- a/source/sql/ed/01-tables.sql
+++ b/source/sql/ed/01-tables.sql
@@ -583,3 +583,26 @@ CREATE TABLE IF NOT EXISTS navitia.admin_stop_area(
     admin_id Text NOT NULL,
     stop_area_id BIGINT NOT NULL REFERENCES navitia.stop_area
 );
+
+-- enum for meta vj 
+DO $$
+BEGIN
+    CASE WHEN (SELECT count(*) = 0 FROM pg_type where pg_type.typname='vj_classification')
+    THEN
+        CREATE TYPE vj_classification AS ENUM ('Theoric', 'Adapted', 'RealTime');
+    ELSE
+        RAISE NOTICE 'vj_classification already exists, skipping';
+    END CASE;
+
+END$$;
+
+CREATE TABLE IF NOT EXISTS navitia.meta_vj(
+    id BIGINT PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS navitia.meta_vj_link(
+    meta_vj BIGINT REFERENCES navitia.meta_vj,
+    vehicle_journey BIGINT REFERENCES navitia.vehicle_journey,
+    vj_class vj_classification NOT NULL
+);

--- a/source/sql/ed/01-tables.sql
+++ b/source/sql/ed/01-tables.sql
@@ -601,7 +601,7 @@ CREATE TABLE IF NOT EXISTS navitia.meta_vj(
     name TEXT NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS navitia.meta_vj_link(
+CREATE TABLE IF NOT EXISTS navitia.rel_metavj_vj(
     meta_vj BIGINT REFERENCES navitia.meta_vj,
     vehicle_journey BIGINT REFERENCES navitia.vehicle_journey,
     vj_class vj_classification NOT NULL

--- a/source/time_tables/departure_boards.cpp
+++ b/source/time_tables/departure_boards.cpp
@@ -235,7 +235,7 @@ departure_board(const std::string& request,
             if(jpp->journey_pattern->route != route) {
                 continue;
             }
-            if(stop_point->idx == jpp->journey_pattern->journey_pattern_point_list.back()->stop_point->idx){ // dans le cas de terminus
+            if(stop_point->idx == jpp->journey_pattern->journey_pattern_point_list.back()->stop_point->idx) { // dans le cas de terminus
                 response_status[route->idx] = pbnavitia::ResponseStatus::terminus;
                 continue;
             }

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -191,17 +191,19 @@ ValidityPattern* Data::get_similar_validity_pattern(ValidityPattern* vp) const{
 
 using list_cal_bitset = std::vector<std::pair<const Calendar*, ValidityPattern::year_bitset>>;
 
-list_cal_bitset find_matching_calendar(const Data&, const VehicleJourney* vehicle_journey, double relative_threshold) {
+list_cal_bitset
+find_matching_calendar(const Data&, const std::string& name, const ValidityPattern& validity_pattern,
+                        const std::vector<Calendar*>& calendar_list, double relative_threshold) {
     list_cal_bitset res;
     //for the moment we keep lot's of trace, but they will be removed after a while
     auto log = log4cplus::Logger::getInstance("kraken::type::Data::Calendar");
-    LOG4CPLUS_TRACE(log, "vj " << vehicle_journey->uri << " :" << vehicle_journey->validity_pattern->days.to_string());
+    LOG4CPLUS_TRACE(log, "meta vj " << name << " :" << validity_pattern.days.to_string());
 
-    for (const auto calendar : vehicle_journey->journey_pattern->route->line->calendar_list) {
-        auto diff = get_difference(calendar->validity_pattern.days, vehicle_journey->validity_pattern->days);
+    for (const auto calendar : calendar_list) {
+        auto diff = get_difference(calendar->validity_pattern.days, validity_pattern.days);
         size_t nb_diff = diff.count();
 
-        LOG4CPLUS_TRACE(log, "cal " << calendar->uri << " :" <<calendar->validity_pattern.days.to_string());
+        LOG4CPLUS_TRACE(log, "cal " << calendar->uri << " :" << calendar->validity_pattern.days.to_string());
 
         //we associate the calendar to the vj if the diff are below a relative threshold
         //compared to the number of active days in the calendar
@@ -249,33 +251,63 @@ void Data::complete(){
     LOG4CPLUS_INFO(logger, "\t Building autocomplete " << autocomplete << "ms");
 }
 
+ValidityPattern get_union_validity_pattern(const MetaVehicleJourney& meta_vj) {
+    ValidityPattern validity;
+
+    for (auto* vj: meta_vj.theoric_vj) {
+        if (validity.beginning_date.is_not_a_date()) {
+            validity.beginning_date = vj->validity_pattern->beginning_date;
+        } else {
+            if (validity.beginning_date != vj->validity_pattern->beginning_date) {
+                throw navitia::exception("the beginning date of the meta_vj are not all the same");
+            }
+        }
+        validity.days |= vj->validity_pattern->days;
+    }
+    return validity;
+}
+
 void Data::build_associated_calendar() {
     auto log = log4cplus::Logger::getInstance("kraken::type::Data");
-    std::multimap<ValidityPattern*, AssociatedCalendar*> associated_vp;
+    std::multimap<ValidityPattern, AssociatedCalendar*> associated_vp;
     size_t nb_not_matched_vj(0);
     size_t nb_matched(0);
-    for(VehicleJourney* vehicle_journey : this->pt_data->vehicle_journeys) {
+    for(auto& meta_vj_pair : this->pt_data->meta_vj) {
+        auto& meta_vj = meta_vj_pair.second;
 
-        if (vehicle_journey->journey_pattern->route->line->calendar_list.empty()) {
-            LOG4CPLUS_TRACE(log, "the line of the vj " << vehicle_journey->uri << " is associated to no calendar");
+        assert (! meta_vj.theoric_vj.empty());
+
+        // we check the theoric vj of a meta vj
+        // because we start from the postulate that the theoric VJs are the same VJ
+        // split because of dst (day saving time)
+        // because of that we try to match the calendar with the union of all theoric vj validity pattern
+        ValidityPattern meta_vj_validity_patern = get_union_validity_pattern(meta_vj);
+
+        //some check can be done on any theoric vj, we do them on the first
+        auto* first_vj = meta_vj.theoric_vj.front();
+        const std::vector<Calendar*> calendar_list = first_vj->journey_pattern->route->line->calendar_list;
+        if (calendar_list.empty()) {
+            LOG4CPLUS_TRACE(log, "the line of the vj " << first_vj->uri << " is associated to no calendar");
             nb_not_matched_vj++;
             continue;
         }
 
         //we check if we already computed the associated val for this validity pattern
         //since a validity pattern can be shared by many vj
-        auto it = associated_vp.find(vehicle_journey->validity_pattern);
+        auto it = associated_vp.find(meta_vj_validity_patern);
         if (it != associated_vp.end()) {
-            for (; it->first == vehicle_journey->validity_pattern; ++it) {
-                vehicle_journey->associated_calendars.insert({it->second->calendar->uri, it->second});
+            for (; it->first == meta_vj_validity_patern; ++it) {
+                for (auto vj: meta_vj.theoric_vj) {
+                    vj->associated_calendars.insert({it->second->calendar->uri, it->second});
+                }
             }
             continue;
         }
 
-        auto close_cal = find_matching_calendar(*this, vehicle_journey);
+        auto close_cal = find_matching_calendar(*this, meta_vj_pair.first, meta_vj_validity_patern, calendar_list);
 
         if (close_cal.empty()) {
-            LOG4CPLUS_TRACE(log, "the vj " << vehicle_journey->uri << " has been attached to no calendar");
+            LOG4CPLUS_TRACE(log, "the meta vj " << meta_vj_pair.first << " has been attached to no calendar");
             nb_not_matched_vj++;
             continue;
         }
@@ -293,18 +325,20 @@ void Data::build_associated_calendar() {
                     continue; //cal_bit_set.second is the resulting differences, so 0 means no exception
                 }
                 ExceptionDate ex;
-                ex.date = vehicle_journey->validity_pattern->beginning_date + boost::gregorian::days(i);
+                ex.date = meta_vj_validity_patern.beginning_date + boost::gregorian::days(i);
                 //if the vj is active this day it's an addition, else a removal
-                ex.type = (vehicle_journey->validity_pattern->days[i] ? ExceptionDate::ExceptionType::add : ExceptionDate::ExceptionType::sub);
+                ex.type = (meta_vj_validity_patern.days[i] ? ExceptionDate::ExceptionType::add : ExceptionDate::ExceptionType::sub);
                 associated_calendar->exceptions.push_back(ex);
             }
 
-            vehicle_journey->associated_calendars.insert({associated_calendar->calendar->uri, associated_calendar});
-            associated_vp.insert({vehicle_journey->validity_pattern, associated_calendar});
+            for (auto vj: meta_vj.theoric_vj) {
+                vj->associated_calendars.insert({associated_calendar->calendar->uri, associated_calendar});
+            }
+            associated_vp.insert({meta_vj_validity_patern, associated_calendar});
             cal_uri << associated_calendar->calendar->uri << " ";
         }
 
-        LOG4CPLUS_DEBUG(log, "the vj " << vehicle_journey->uri << " has been attached to " << cal_uri.str());
+        LOG4CPLUS_DEBUG(log, "the meta vj " << meta_vj_pair.first << " has been attached to " << cal_uri.str());
     }
 
     LOG4CPLUS_INFO(log, nb_matched << " vehicle journeys have been matched to at least one calendar");

--- a/source/type/data.h
+++ b/source/type/data.h
@@ -201,7 +201,8 @@ std::bitset<N> get_difference(const std::bitset<N>& calendar, const std::bitset<
 }
 
 std::vector<std::pair<const Calendar*, ValidityPattern::year_bitset>>
-find_matching_calendar(const Data& data, const VehicleJourney* vehicle_journey, double relative_threshold = 0.1);
+find_matching_calendar(const Data&, const std::string& name, const ValidityPattern& validity_pattern,
+                       const std::vector<Calendar*>& calendar_list, double relative_threshold = 0.1);
 
 }} //namespace navitia::type
 

--- a/source/type/pt_data.h
+++ b/source/type/pt_data.h
@@ -51,6 +51,9 @@ struct PT_Data : boost::noncopyable{
     std::vector<StopTime*> stop_times;
     std::vector<StopPointConnection*> stop_point_connections;
 
+    // meta vj map
+    std::map<std::string, MetaVehicleJourney> meta_vj;
+
     //associated cal for vj
     std::vector<AssociatedCalendar*> associated_calendars;
 
@@ -75,14 +78,16 @@ struct PT_Data : boost::noncopyable{
         #define SERIALIZE_ELEMENTS(type_name, collection_name) & collection_name & collection_name##_map
                 ITERATE_NAVITIA_PT_TYPES(SERIALIZE_ELEMENTS)
                 & stop_times
-                // Les firstLetter
-                & stop_area_autocomplete & stop_point_autocomplete
-                // Les proximity list
-                & stop_area_proximity_list & stop_point_proximity_list & line_autocomplete
-                // Les types un peu spéciaux
+                // the first letters for autocomplete
+                & stop_area_autocomplete & stop_point_autocomplete & line_autocomplete
+                // the proximity lists
+                & stop_area_proximity_list & stop_point_proximity_list
+                // custom types
                 & stop_point_connections
-                //les messages
-                & message_holder;
+                //messages
+                & message_holder
+                //the meta vjs
+                & meta_vj;
     }
 
     /** Initialise tous les indexes

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -646,7 +646,7 @@ struct Route : public Header, Nameable, HasMessages, Codes{
 struct JourneyPattern : public Header, Nameable{
     const static Type_e type = Type_e::JourneyPattern;
     bool is_frequence;
-    OdtLevel_e odt_level; // Calculated at serialization
+    OdtLevel_e odt_level; // Computed at serialization
     Route* route;
     CommercialMode* commercial_mode;
     PhysicalMode* physical_mode;
@@ -969,6 +969,29 @@ struct Calendar : public Nameable, public Header, public Codes {
     }
 };
 
+/**
+ * A meta vj is a shell around some vehicle journeys
+ *
+ * It have 2 purposes:
+ *
+ *  - to store the adapted and real time vj
+ *
+ *  - sometime we have to split a vj.
+ *    For example we have to split a vj because of dst (day saving light see gtfs parser for that)
+ *    the meta vj can thus make the link between the split vjs
+ *
+ *
+ */
+struct MetaVehicleJourney {
+    //store the name ?
+    std::vector<VehicleJourney*> theoric_vj;
+    std::vector<VehicleJourney*> adapted_vj;
+    std::vector<VehicleJourney*> real_time_vj;
+
+    template<class Archive> void serialize(Archive & ar, const unsigned int ) {
+        ar & theoric_vj & adapted_vj & real_time_vj;
+    }
+};
 
 struct static_data {
 private:

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -979,11 +979,15 @@ struct Calendar : public Nameable, public Header, public Codes {
  *  - sometime we have to split a vj.
  *    For example we have to split a vj because of dst (day saving light see gtfs parser for that)
  *    the meta vj can thus make the link between the split vjs
+ *    *NOTE*: An IMPORTANT prerequisite is that ALL theoric vj have the same local time
+ *            (even if the UTC time is different because of DST)
+ *            That prerequisite is very important for calendar association and departure board over period
  *
  *
  */
 struct MetaVehicleJourney {
     //store the name ?
+    //TODO if needed use a flat_enum_map
     std::vector<VehicleJourney*> theoric_vj;
     std::vector<VehicleJourney*> adapted_vj;
     std::vector<VehicleJourney*> real_time_vj;

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -972,7 +972,7 @@ struct Calendar : public Nameable, public Header, public Codes {
 /**
  * A meta vj is a shell around some vehicle journeys
  *
- * It have 2 purposes:
+ * It has 2 purposes:
  *
  *  - to store the adapted and real time vj
  *


### PR DESCRIPTION
meta vj shell around vehicle journeys

It have 2 purposes:
- to store the adapted and real time vj
- sometime we have to split a vj.
  
  For example we have to split a vj because of dst (day saving light see gtfs parser for that)
  the meta vj can thus make the link between the split vjs
  
  **NOTE**: An IMPORTANT prerequisite is that ALL theoric vj have the same local time
  (even if the UTC time is different because of DST).
  
  That prerequisite is very important for calendar association and departure board over period
