### PR TITLE
TimeTable: fix departure board for calendar

### DIFF
--- a/source/ed/connectors/fusio_parser.cpp
+++ b/source/ed/connectors/fusio_parser.cpp
@@ -359,6 +359,10 @@ std::vector<ed::types::VehicleJourney*> TripsFusioHandler::get_split_vj(Data& da
         res.push_back(vj);
         meta_vj.theoric_vj.push_back(vj);
         vj->meta_vj_name = row[trip_c];
+
+        // we store the split vj utc shift
+        auto utc_offset = gtfs_data.tz.offset_by_vp[vp_xx];
+        vj->utc_to_local_offset = utc_offset;
     }
 
     return res;

--- a/source/ed/connectors/gtfs_parser.cpp
+++ b/source/ed/connectors/gtfs_parser.cpp
@@ -786,6 +786,10 @@ void TripsGtfsHandler::handle_line(Data& data, const csv_row& row, bool) {
         //we add them on our meta vj
         meta_vj.theoric_vj.push_back(vj);
         vj->meta_vj_name = row[trip_c];
+
+        // we store the split vj utc shift
+        auto utc_offset = gtfs_data.tz.offset_by_vp[vp_xx];
+        vj->utc_to_local_offset = utc_offset;
     }
 
 }

--- a/source/ed/ed_persistor.cpp
+++ b/source/ed/ed_persistor.cpp
@@ -842,7 +842,7 @@ void EdPersistor::insert_vehicle_journeys(const std::vector<types::VehicleJourne
              "start_time", "end_time", "headway_sec",
              "adapted_validity_pattern_id", "company_id", "journey_pattern_id",
              "theoric_vehicle_journey_id", "vehicle_properties_id",
-             "odt_type_id", "odt_message"});
+             "odt_type_id", "odt_message, utc_to_local_offset"});
 
     for(types::VehicleJourney* vj : vehicle_journeys){
         std::vector<std::string> values;
@@ -886,6 +886,7 @@ void EdPersistor::insert_vehicle_journeys(const std::vector<types::VehicleJourne
         values.push_back(std::to_string(vj->to_ulog()));
         values.push_back(std::to_string(static_cast<int>(vj->vehicle_journey_type)));
         values.push_back(vj->odt_message);
+        values.push_back(std::to_string(vj->utc_to_local_offset));
         this->lotus.insert(values);
     }
     this->lotus.finish_bulk_insert();

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -620,6 +620,7 @@ void EdReader::fill_vehicle_journeys(nt::Data& data, pqxx::work& work){
         "vj.start_time as start_time,"
         "vj.end_time as end_time,"
         "vj.headway_sec as headway_sec,"
+        "vj.utc_to_local_offset as utc_to_local_offset, "
         "vp.wheelchair_accessible as wheelchair_accessible,"
         "vp.bike_accepted as bike_accepted,"
         "vp.air_conditioned as air_conditioned,"
@@ -640,6 +641,7 @@ void EdReader::fill_vehicle_journeys(nt::Data& data, pqxx::work& work){
         const_it["name"].to(vj->name);
         const_it["comment"].to(vj->comment);
         const_it["odt_message"].to(vj->odt_message);
+        const_it["utc_to_local_offset"].to(vj->utc_to_local_offset);
         const_it["external_code"].to(vj->codes["external_code"]);
         vj->vehicle_journey_type = static_cast<nt::VehicleJourneyType>(const_it["odt_type_id"].as<int>());
 
@@ -743,6 +745,7 @@ void EdReader::fill_meta_vehicle_journeys(nt::Data& data, pqxx::work& work) {
         } else {
             throw navitia::exception("technical error, vj class for meta vj should be either Theoric, Adapted or RealTime");
         }
+        vj->meta_vj = meta_vj;
     }
 }
 

--- a/source/ed/types.h
+++ b/source/ed/types.h
@@ -225,6 +225,7 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties{
     std::string block_id;
     std::string odt_message;
     std::string meta_vj_name; //link to it's meta vj
+    int16_t utc_to_local_offset = 0; // shift used to convert the local time from the data to utc, in minute
 
     int start_time = std::numeric_limits<int>::max(); /// First departure of vehicle
     int end_time = std::numeric_limits<int>::max(); /// Last departure of vehicle journey

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -102,7 +102,7 @@ class Schedules(ResourceUri):
 
 
 date_time = {
-    "date_time": SplitDateTime(date='date', time='time'),  # TODO!
+    "date_time": SplitDateTime(date='date', time='time'),
     "additional_informations": additional_informations(),
     "links": stop_time_properties_links()
 }

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -91,6 +91,14 @@ class SplitDateTime(DateTime):
     custom date format from 2 fields:
       - one for the date (in timestamp to midnight)
       - one for the time in seconds from midnight
+
+      the date can be null (for example when the time is for a period like for calendar schedule)
+
+      if the date is not null be convert to local using the default timezone
+
+      if the date is null, we do not convert anything.
+            Thus the given date HAS to be previously converted to local
+            if that is what is wanted
     """
     def __init__(self, date, time, *args, **kwargs):
         super(DateTime, self).__init__(*args, **kwargs)
@@ -98,8 +106,21 @@ class SplitDateTime(DateTime):
         self.time = time
 
     def output(self, key, obj):
-        #TODO!!
-        return None
+
+        date = fields.get_value(self.date, obj)
+        time = fields.get_value(self.time, obj)
+
+        if not date:
+            return self.format_time(time)
+
+        date_time = date + time
+        tz = get_timezone()
+        return self.format(date_time, timezone=tz)
+
+    @staticmethod
+    def format_time(time):
+        t = datetime.datetime.utcfromtimestamp(time)
+        return t.strftime("%H%M%S")
 
 
 class enum_type(fields.Raw):

--- a/source/jormungandr/tests/departure_board_tests.py
+++ b/source/jormungandr/tests/departure_board_tests.py
@@ -47,12 +47,12 @@ def check_departure_board(schedules, tester, only_time=False):
 
     assert len(datetimes) != 0, "we have to have date_times"
     #TODO, make that works before merging the time zone
-    # for dt_wrapper in datetimes:
-    #     dt = dt_wrapper["date_time"]
-    #     if only_time:
-    #         get_valid_time(dt)
-    #     else:
-    #         get_valid_datetime(dt)
+    for dt_wrapper in datetimes:
+        dt = dt_wrapper["date_time"]
+        if only_time:
+            get_valid_time(dt)
+        else:
+            get_valid_datetime(dt)
 
     #TODO uncomment after link refactor
     #check_links(schedule, tester)

--- a/source/routing/best_stoptime.cpp
+++ b/source/routing/best_stoptime.cpp
@@ -137,6 +137,7 @@ earliest_stop_time(const type::JourneyPatternPoint* jpp,
             const DateTime tmp_dt = f_departure_time(DateTimeUtils::hour(first_st.second), first_st.first);
             DateTimeUtils::update(first_st.second, DateTimeUtils::hour(tmp_dt));
         }
+
         return first_st;
     }
     return {nullptr, 0};
@@ -187,6 +188,10 @@ earliest_stop_time(const type::JourneyPatternPoint* jpp,
                     DateTimeUtils::hour(f_departure_time(time, st)) :
                     //else we only got the departure of the stop time
                     st->departure_time;
+
+        //we need to convert this to local there since we do not have a precise date (just a period)
+        departure_time += vj->utc_to_local_offset;
+
         if (departure_time < time) {
             continue;
         }

--- a/source/sql/ed/02-migration.sql
+++ b/source/sql/ed/02-migration.sql
@@ -204,6 +204,17 @@ DO $$
 $$;
 
 DO $$
+    BEGIN
+        BEGIN
+            ALTER TABLE navitia.vehicle_journey ADD
+                COLUMN utc_to_local_offset INT REFERENCES navitia.vehicle_journey;
+        EXCEPTION
+            WHEN duplicate_column THEN RAISE NOTICE 'column utc_to_local_offset already exists in navitia.vehicle_journey';
+        END;
+    END;
+$$;
+
+DO $$
     DECLARE count_admin int;
 BEGIN
     count_admin := coalesce((select  count(*) from  pg_catalog.pg_tables where schemaname = 'navitia' and tablename='admin'), 0);

--- a/source/time_tables/request_handle.cpp
+++ b/source/time_tables/request_handle.cpp
@@ -44,7 +44,8 @@ RequestHandle::RequestHandle(const std::string& /*api*/, const std::string &requ
         auto ptime = boost::posix_time::from_iso_string(str_dt);
 
         if (! calendar_id) {
-            //if we have a calendar, we don't check the production period since we are only interested in the time, not the date
+            //we only have to check the production period if we do not have a calendar,
+            // since if we have one we are only interested in the time, not the date
             if(! data.meta->production_date.contains(ptime.date()) ) {
                 fill_pb_error(pbnavitia::Error::date_out_of_bounds, "date is out of bound",pb_response.mutable_error());
             } else if( !data.meta->production_date.contains((ptime + boost::posix_time::seconds(duration)).date()) ) {

--- a/source/type/CMakeLists.txt
+++ b/source/type/CMakeLists.txt
@@ -3,7 +3,7 @@ PROTOBUF_GENERATE_CPP(PROTO_SRCS PROTO_HDRS type.proto response.proto request.pr
 
 
 add_library(pb_lib ${PROTO_SRCS} pb_converter.cpp)
-target_link_libraries(pb_lib ${PROTOBUF_LIBRARY})
+target_link_libraries(pb_lib pthread ${PROTOBUF_LIBRARY})
 add_custom_command (TARGET pb_lib
     PRE_BUILD
     COMMAND protoc ARGS "--python_out=${CMAKE_SOURCE_DIR}/navitiacommon/navitiacommon" type.proto

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -702,6 +702,12 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties, HasMessage
     uint32_t end_time = std::numeric_limits<uint32_t>::max(); ///< If frequency-modeled, last departure
     uint32_t headway_secs = std::numeric_limits<uint32_t>::max(); ///< Seconds between each departure.
 
+    // all times are stored in UTC
+    // however, sometime we do not have a date to convert the time to a local value (in jormungandr)
+    // For example for departure board over a period (calendar)
+    // thus we store the shit needed to convert all stop times of the vehicle journey to local
+    int16_t utc_to_local_offset = 0; //in minutes
+
     bool is_adapted = false; //REMOVE (change to enum ?)
     ValidityPattern* adapted_validity_pattern = nullptr; //REMOVE
     std::vector<VehicleJourney*> adapted_vehicle_journey_list; //REMOVE
@@ -714,7 +720,7 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties, HasMessage
             & theoric_vehicle_journey & comment & vehicle_journey_type
             & odt_message & _vehicle_properties & messages
             & codes & next_vj & prev_vj & start_time & end_time & headway_secs
-			& meta_vj;
+            & meta_vj & utc_to_local_offset;
     }
     std::string get_direction() const;
     bool has_date_time_estimated() const;


### PR DESCRIPTION
In kraken all times are stored in UTC

however, for calendar we do not have a date to convert the time to a
local value (the conversion should be in jormungandr)

The for the calendar departure board api, we store in all vj the utc
offset needed to convert all stop times of the vehicle journey to local.

Thus:
- when queried with a date time the departure board answers in UTC and
  the conversion is done in jormun
- when queried with a calendar the departure board answers in local
  time
