### PR TITLE
Protobuff: change date from int32 to int64

### DIFF
--- a/source/type/request.proto
+++ b/source/type/request.proto
@@ -62,7 +62,7 @@ message StreetNetworkParams{
 message JourneysRequest {
     required string origin                              = 1;
     optional string destination                         = 2;
-    repeated uint32 datetimes                           = 3;
+    repeated uint64 datetimes                           = 3;
     required bool clockwise                             = 4;
     repeated string forbidden_uris                      = 5;
     required int32 max_duration                         = 6;

--- a/source/type/response.proto
+++ b/source/type/response.proto
@@ -142,8 +142,8 @@ message Section {
     optional string polyline = 14;
     optional int32 duration = 15;
 
-    optional uint32 begin_date_time = 16;
-    optional uint32 end_date_time = 17;
+    optional uint64 begin_date_time = 16;
+    optional uint64 end_date_time = 17;
     optional addInfoVehicleJourney add_info_vehicle_journey = 18;
     optional int32 length = 19;
     optional string id = 20;
@@ -152,9 +152,9 @@ message Section {
 message Journey {
     optional int32 duration = 1;
     optional int32 nb_transfers = 2;
-    optional uint32 departure_date_time = 3;
-    optional uint32 arrival_date_time = 4;
-    optional uint32 requested_date_time = 5;
+    optional uint64 departure_date_time = 3;
+    optional uint64 arrival_date_time = 4;
+    optional uint64 requested_date_time = 5;
     repeated Section sections = 6;
     optional Place origin = 7;
     optional Place destination = 8;
@@ -212,8 +212,8 @@ message ScheduleStopTime {
     optional Properties properties = 2;
     // date time is split because sometimes 
     // we want only time and no dates for the schedule
-    optional uint32 time = 3; //time is the number of seconds since midnight
-    optional uint32 date = 4; //date is a posix time stamp to midnight
+    optional uint64 time = 3; //time is the number of seconds since midnight
+    optional uint64 date = 4; //date is a posix time stamp to midnight
 }
 
 message RouteScheduleRow {

--- a/source/type/type.proto
+++ b/source/type/type.proto
@@ -217,16 +217,16 @@ message hasEquipments{
 }
 
 message StopDateTime {
-    optional uint32 arrival_date_time = 1; //posix time
-    optional uint32 departure_date_time = 2;
+    optional uint64 arrival_date_time = 1; //posix time
+    optional uint64 departure_date_time = 2;
     optional StopPoint stop_point = 3;
     optional Properties properties = 4;
 }
 
 
 message StopTime {
-    optional uint32 arrival_time = 1;
-    optional uint32 departure_time = 3; //nb seconds from midnight
+    optional uint64 arrival_time = 1;
+    optional uint64 departure_time = 3; //nb seconds from midnight
     optional VehicleJourney vehicle_journey = 4;
     optional JourneyPatternPoint journey_pattern_point = 5;
     optional bool pickup_allowed = 6;


### PR DESCRIPTION
protobuff compact the types and google recommendation for dates are
uint64, so we're safe after 2038 :p
